### PR TITLE
Included browser key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "css-houdini-squircle",
   "version": "0.2.1",
   "private": false,
+  "browser": "squircle.min.js",
   "homepage": "./",
   "devDependencies": {
     "node-sass": "^5.0.0",


### PR DESCRIPTION
Included the `"browser"` key in the package.json, for tidier import statements. For example:

```javascript
// Current
import 'css-houdini-squircle/squircle-min.js';

// Updated
import 'css-houdini-squircle';
```

The `"browser"` key also highlights that this package is to be used client-side.

See:
- https://docs.npmjs.com/cli/v9/configuring-npm/package-json#browser
- https://gist.github.com/defunctzombie/4339901/49493836fb873ddaa4b8a7aa0ef2352119f69211