### PR TITLE
Fix typo ("Preformance")

### DIFF
--- a/src/sections/BenefitsSection/index.js
+++ b/src/sections/BenefitsSection/index.js
@@ -147,7 +147,7 @@ const BenefitsSection = () => {
           smooth={0}
         />
         <Card
-          title="Fast preformance"
+          title="Fast performance"
           svg={svgIcons.fast}
           radius={12}
           smooth={0.8}


### PR DESCRIPTION
Awesome use of Houdini! I just noticed the first example is a bit messed up too:

```css
background: color
mask-image: paint(squircle)
background: color mask-image: paint(squircle)
--squircle-radius: px
--squircle-smooth: number
```

`background` and `mask-image` are accidentally repeated. I had to add semicolons and use `-webkit-mask-image` but perhaps everyone is using a CSS tool that makes this unnecessary.
Thanks!